### PR TITLE
Added 'scale' to axis properties, 'props', dictionary.

### DIFF
--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -215,6 +215,9 @@ def get_axis_properties(axis):
     else:
         props['tickformat'] = None
 
+    # Get axis scale
+    props['scale'] = axis.get_scale()
+
     # Get associated grid
     props['grid'] = get_grid_style(axis)
 


### PR DESCRIPTION
Really tiny change, I was going to email you, but I figured it was just as easy to do it this way.

The 'scale' parameter will be 'linear' or 'log'.

I'm having a bit of a hard time understanding the output from the `ax.xaxis.get_major_locator()()` call. It makes sense when using the linear scale, but seems to yield too many values when using the log scale. Try the following to see what I mean:

```
fig = plt.figure()
ax = fig.add_subplot(111)
ax.plot(range(1,1000), range(1,1000))
ax.semilogx()
print list(ax.yaxis.get_major_locator()())  # makes sense...
print list(ax.xaxis.get_major_locator()())  # close, 10e-1 to 10e4, but should be 10e0 to 10e3
print list(ax.xaxis.get_major_locator().tick_values(10,99)) # this is what we wanted!
# Output: 
# [0.0, 200.0, 400.0, 600.0, 800.0, 1000.0]
# [0.10000000000000001, 1.0, 10.0, 100.0, 1000.0, 10000.0]
# [1.0, 10.0, 100.0, 1000.0]
```

Have you come across this at all?
