### PR TITLE
Add fontsize

### DIFF
--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -219,9 +219,9 @@ def get_axis_properties(axis):
     props['scale'] = axis.get_scale()
 
     # Get major tick label size (assumes that's all we really care about!)
-    sizes = [tick.get_fontsize() for tick in axis.get_ticklabels()]
-    if sizes[1:] == sizes[:-1]:
-        props['fontsize'] = sizes[0]
+    labels = axis.get_ticklabels()
+    if labels:
+        props['fontsize'] = labels[0].get_fontsize()
     else:
         props['fontsize'] = None
 


### PR DESCRIPTION
Additional 'fontsize' added to get_axis_properties in utils.

You may decide to rework how I did this, so I set this up as a separate pull request. The info's in the commit message below!

A major barrier we seem to be butting up against is getting the formatting of the labels to look right. Obviously we don't want the exporter to have to pass EVERYTHING, only what's important to make the plot look 'good'. I think this is a helpful item for a renderer to have.

Cheers,

Andrew
