### PR TITLE
Added ['style']['markersize'] to utils.get_marker_style.

### DIFF
--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -161,6 +161,7 @@ def get_marker_style(line):
                        + Affine2D().scale(markersize, -markersize))
     style['markerpath'] = SVG_path(markerstyle.get_path(),
                                    markertransform)
+    style['markersize'] = markersize
     style['zorder'] = line.get_zorder()
     return style
 


### PR DESCRIPTION
For renderers that want high-level information, 'markersize' would be a
useful parameter. Otherwise, if renderers want a simple size in points,
it has to use the affine transform and the figure's dpi to figure it
out.
