### PR TITLE
Merged the drawing of lines and markers, no more draw_markers.

### DIFF
--- a/mplexporter/exporter.py
+++ b/mplexporter/exporter.py
@@ -159,22 +159,26 @@ class Exporter(object):
                                       & child)
 
     def draw_line(self, ax, line, force_trans=None):
-        """Process a matplotlib line and call renderer.draw_line"""
+        """Process a matplotlib line and call renderer.draw_line.
+
+        The mpl Line2D instances have both line and marker attributes. The
+        style dict will contain information about both of these attributes.
+        Depending on the mixture of lines and/or markers, the 'types'
+        can be: ['line'], ['marker'], ['line', 'marker'].
+
+        """
         coordinates, data = self.process_transform(line.get_transform(),
                                                    ax, line.get_xydata(),
                                                    force_trans=force_trans)
-        linestyle = utils.get_line_style(line)
-        if linestyle['dasharray'] not in ['None', 'none', None]:
-            self.renderer.draw_line(data=data,
-                                    coordinates=coordinates,
-                                    style=linestyle, mplobj=line)
-
-        markerstyle = utils.get_marker_style(line)
-        if markerstyle['marker'] not in ['None', 'none', None]:
-            if markerstyle['markerpath'][0].size > 0:
-                self.renderer.draw_markers(data=data,
-                                           coordinates=coordinates,
-                                           style=markerstyle, mplobj=line)
+        style = utils.get_line_style(line)
+        label = line.get_label()
+        types = []
+        if style['dasharray'] not in ['None', 'none', None]:
+            types += 'line',
+        if style['marker'] not in ['None', 'none', None]:
+            types += 'marker'
+        self.renderer.draw_line(data=data, coordinates=coordinates, style=style,
+                                types=types, label=label, mplobj=line)
 
     def draw_text(self, ax, text, force_trans=None, text_type=None):
         """Process a matplotlib text object and call renderer.draw_text"""

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -131,7 +131,7 @@ def get_path_style(path, fill=True):
 
 
 def get_line_style(line):
-    """Get the style dictionary for matplotlib line objects"""
+    """Get the style dictionary for matplotlib Line2D objects."""
     style = {}
     style['alpha'] = line.get_alpha()
     if style['alpha'] is None:
@@ -139,28 +139,15 @@ def get_line_style(line):
     style['color'] = color_to_hex(line.get_color())
     style['linewidth'] = line.get_linewidth()
     style['dasharray'] = get_dasharray(line)
-    style['zorder'] = line.get_zorder()
-    return style
-
-
-def get_marker_style(line):
-    """Get the style dictionary for matplotlib marker objects"""
-    style = {}
-    style['alpha'] = line.get_alpha()
-    if style['alpha'] is None:
-        style['alpha'] = 1
-
     style['facecolor'] = color_to_hex(line.get_markerfacecolor())
     style['edgecolor'] = color_to_hex(line.get_markeredgecolor())
     style['edgewidth'] = line.get_markeredgewidth()
-
     style['marker'] = line.get_marker()
     markerstyle = MarkerStyle(line.get_marker())
     markersize = line.get_markersize()
     markertransform = (markerstyle.get_transform()
                        + Affine2D().scale(markersize, -markersize))
-    style['markerpath'] = SVG_path(markerstyle.get_path(),
-                                   markertransform)
+    style['markerpath'] = SVG_path(markerstyle.get_path(), markertransform)
     style['markersize'] = markersize
     style['zorder'] = line.get_zorder()
     return style


### PR DESCRIPTION
Functions modified:
- draw_line (exporter)
- get_line_style (utils)

Functions deleted:
- get_marker_style (utils)

Functions requiring modification/deletion in renderers:
- self.draw_line
- self.draw_markers (may or may not need modification or deletion)

Since both markers and lines are really just `Line2D` objects in mpl, they
can just be treated together. Rather than have the exporter decide that
they should be treated differently (i.e., call to `draw_line` or
`draw_markers`), the exporter now just gives the line, the style, and a
`types` indicator.

The `types` indicator is a list of the objects within the line that a
renderer needs to deal with. It can have one, none, or both of the
following entries: `'line'`, `'marker'`.

This is very helpful to high-level renderers. For instance, Plotly links
data with lines/markers, therefore, if a call is made to draw markers
and then another call is made to draw lines, an extra trace is created
unnecessarily. Of course, this can be handled by storing the lines and
messing with the line objects on the renderer side, but I think this
saves the hassle and don't see how it would hinder other renderers that
want to draw the SVG paths for markers and such.

Finally, though the exporter passes all of the text objects through,
`Line2D` labels are not passed. Therefore, I included it as a property
(not contained within the style dict). Another example from plotly: all
pieces of data have a name attached to them in plotly. When you hover
over data, this name appears. If mpl users care to enter a 'label' for
their `Line2D` objects, this should be preserved and could, for instance,
show up in the hover or in the data spreadsheet in plotly.

Where there any reasons the Line2D objects were getting split into markers and lines that make this a bad idea?
