### PR TITLE
Allow renderers to deal with Line2D objects that have lines and markers.

### DIFF
--- a/mplexporter/exporter.py
+++ b/mplexporter/exporter.py
@@ -164,17 +164,32 @@ class Exporter(object):
                                                    ax, line.get_xydata(),
                                                    force_trans=force_trans)
         linestyle = utils.get_line_style(line)
-        if linestyle['dasharray'] not in ['None', 'none', None]:
-            self.renderer.draw_line(data=data,
-                                    coordinates=coordinates,
-                                    style=linestyle, mplobj=line)
-
         markerstyle = utils.get_marker_style(line)
-        if markerstyle['marker'] not in ['None', 'none', None]:
+        label = line.get_label()
+        markers = markerstyle['marker'] not in ['None', 'none', None]
+        lines = linestyle['dasharray'] not in ['None', 'none', None]
+        if lines and markers:
+            self.renderer.draw_marked_line(data=data,
+                                           coordinates=coordinates,
+                                           linestyle=linestyle,
+                                           markerstyle=markerstyle,
+                                           label=label,
+                                           mplobj=line)
+        elif markers:
             if markerstyle['markerpath'][0].size > 0:
                 self.renderer.draw_markers(data=data,
                                            coordinates=coordinates,
-                                           style=markerstyle, mplobj=line)
+                                           style=markerstyle,
+                                           label=label,
+                                           mplobj=line)
+        elif lines:
+            self.renderer.draw_line(data=data,
+                                    coordinates=coordinates,
+                                    style=linestyle,
+                                    label=label,
+                                    mplobj=line)
+        else:
+            pass  # I think this should be an impossible case?
 
     def draw_text(self, ax, text, force_trans=None, text_type=None):
         """Process a matplotlib text object and call renderer.draw_text"""

--- a/mplexporter/renderers/base.py
+++ b/mplexporter/renderers/base.py
@@ -107,7 +107,18 @@ class Renderer(object):
         """
         pass
 
-    def draw_line(self, data, coordinates, style, mplobj=None):
+    def draw_marked_line(self, data, coordinates, linestyle, markerstyle,
+                         label, mplobj=None):
+        """Draw a line that also has markers.
+
+        If this isn't reimplemented by a renderer object, by default, it will
+        make a call to BOTH draw_line and draw_markers.
+
+        """
+        self.draw_line(data, coordinates, linestyle, label, mplobj)
+        self.draw_markers(data, coordinates, markerstyle, label, mplobj)
+
+    def draw_line(self, data, coordinates, style, label, mplobj=None):
         """
         Draw a line. By default, draw the line via the draw_path() command.
         Some renderers might wish to override this and provide more
@@ -222,7 +233,7 @@ class Renderer(object):
                            offset_coordinates=offset_coordinates,
                            mplobj=mplobj)
 
-    def draw_markers(self, data, coordinates, style, mplobj=None):
+    def draw_markers(self, data, coordinates, style, label, mplobj=None):
         """
         Draw a set of markers. By default, this is done by repeatedly
         calling draw_path(), but renderers should generally overload


### PR DESCRIPTION
For renderers wanting to draw the SVG renderings for lines and markers,
it's best to have separate commands, `draw_line`, and `draw_markers`.
However, some high-level renderers will want to know when they can
aggregate these lines and markers into a reference to the same Line2D
object. That is, they don't want import TWO things that represent the
same data.

The base class now accepts an option to `draw_marked_line` that by
default calls both `draw_line` AND `draw_markers`. However, this can be
reimplemented if desired.
