### PR TITLE
Changed the way mplexporter does legend support.

### DIFF
--- a/mplexporter/renderers/base.py
+++ b/mplexporter/renderers/base.py
@@ -107,6 +107,14 @@ class Renderer(object):
         """
         pass
 
+    def draw_legend(self, line_calls, path_calls, text_calls):
+        for call in line_calls:
+            self.draw_line(**call)
+        for call in path_calls:
+            self.draw_path(**call)
+        for call in text_calls:
+            self.draw_text(**call)
+
     def draw_marked_line(self, data, coordinates, linestyle, markerstyle,
                          label, mplobj=None):
         """Draw a line that also has markers.


### PR DESCRIPTION
While crawling an axes object, the exporter would make calls to its
renderer object when need be.

NOW, exporter has a draw_legend method that stores all the necessary
calls to the renderer object in three categories: `line_calls`,
`path_calls`, and `text_calls`.

`get_return` arguments were added to: `draw_line`, `draw_patch`, and
`draw_text` in the exporter. This basically makes a dictionary of all of
the keyword arguments that are required for the call and returns this
dictionary INSTEAD of calling the renderer.

A new method, `draw_legend` was included in the base class which takes
the above-mentioned `line_calls`, `path_calls`, and `text_calls`
arguments. It goes through each call and makes an appropriate call to
its own `draw_line`, `draw_path`, and `draw_text` methods.

This checks out OK with nosetests.

Result: high-level renderers (like plotly) can deal with the legend as a
single entity all at once or choose to ignore these calls by
reimplementing the `base.Renderer.draw_legend` method.
