### PR TITLE
TST: Specify figsize in image test, overriding unknown default.

### DIFF
--- a/mplexporter/tests/test_basic.py
+++ b/mplexporter/tests/test_basic.py
@@ -149,15 +149,14 @@ def test_multiaxes():
 
 def test_image():
     np.random.seed(0)  # image size depends on the seed
-    fig, ax = plt.subplots()
+    fig, ax = plt.subplots(figsize=(2, 2))
     ax.imshow(np.random.random((10, 10)),
               cmap=plt.cm.jet, interpolation='nearest')
-
     _assert_output_equal(fake_renderer_output(fig, FakeRenderer),
                          """
                          opening figure
                          opening axes
-                         draw image of size 2848
+                         draw image of size 1240 
                          closing axes
                          closing figure
                          """)


### PR DESCRIPTION
Closes #21 

The most direct fix is to specify the figure size of the test figure. One can imagine related issues, and eventually we may want to standardize the rcParams in the test environment. But I believe there is ongoing work on mpl to handle rcParams a little differently, which will make it easier to create non-overwriting styles in the future. For now, maybe a simple approach is best.
