### PR TITLE
ENH: include tickformat data from ticker.FixedFormatter

### DIFF
--- a/mplexporter/tests/test_utils.py
+++ b/mplexporter/tests/test_utils.py
@@ -9,3 +9,12 @@ def test_path_data():
 
     assert_allclose(vertices.shape, (25, 2))
     assert_equal(codes, ['M', 'C', 'C', 'C', 'C', 'C', 'C', 'C', 'C', 'Z'])
+
+def test_axis_w_fixed_formatter():
+    positions, labels = [0, 1, 10], ['A','B','C']
+
+    plt.xticks(positions, labels)
+    props = utils.get_axis_properties(plt.gca().xaxis)
+
+    assert_equal(props['tickvalues'], positions)
+    assert_equal(props['tickformat'], labels)

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -213,6 +213,8 @@ def get_axis_properties(axis):
     formatter = axis.get_major_formatter()
     if isinstance(formatter, ticker.NullFormatter):
         props['tickformat'] = ""
+    elif isinstance(formatter, ticker.FixedFormatter):
+        props['tickformat'] = list(formatter.seq)
     elif not any(label.get_visible() for label in axis.get_ticklabels()):
         props['tickformat'] = ""
     else:


### PR DESCRIPTION
necessary for making plt.xticks, etc. work
