### PR TITLE
multialignment is used when '\n' (newlines) exist in text

### DIFF
--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -178,6 +178,7 @@ def get_text_style(text):
     style['color'] = color_to_hex(text.get_color())
     style['halign'] = text.get_horizontalalignment()  # left, center, right
     style['valign'] = text.get_verticalalignment()  # baseline, center, top
+    style['malign'] = text._multialignment # text alignment when '\n' in text
     style['rotation'] = text.get_rotation()
     style['zorder'] = text.get_zorder()
     return style


### PR DESCRIPTION
If there are _no_ newlines, `text._multialignment == None`

If `text._multialignment` has _not_ been set, matplotlib will
default this value to equal `text._horizontalalignment`,
for reference.
