### PR TITLE
added patch visibility and axis visibility props

### DIFF
--- a/mplexporter/exporter.py
+++ b/mplexporter/exporter.py
@@ -181,7 +181,7 @@ class Exporter(object):
                                                    ax, line.get_xydata(),
                                                    force_trans=force_trans)
         linestyle = utils.get_line_style(line)
-        if linestyle['dasharray'] in ['None', 'none', None]:
+        if linestyle['dasharray'] is None:
             linestyle = None
         markerstyle = utils.get_marker_style(line)
         if (markerstyle['marker'] in ['None', 'none', None]

--- a/mplexporter/tests/__init__.py
+++ b/mplexporter/tests/__init__.py
@@ -1,0 +1,3 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt

--- a/mplexporter/tests/test_basic.py
+++ b/mplexporter/tests/test_basic.py
@@ -1,12 +1,9 @@
-from ..exporter import Exporter
-from ..renderers import FakeRenderer, FullFakeRenderer
-
-import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
-
 import numpy as np
 from numpy.testing import assert_warns
+
+from ..exporter import Exporter
+from ..renderers import FakeRenderer, FullFakeRenderer
+from . import plt
 
 
 def fake_renderer_output(fig, Renderer):
@@ -165,7 +162,7 @@ def test_image():
 
 def test_legend():
     fig, ax = plt.subplots()
-    ax.plot([1,2,3], label='label')
+    ax.plot([1, 2, 3], label='label')
     ax.legend().set_visible(False)
     _assert_output_equal(fake_renderer_output(fig, FakeRenderer),
                          """
@@ -178,10 +175,11 @@ def test_legend():
                          closing figure
                          """)
 
+
 def test_legend_dots():
     fig, ax = plt.subplots()
-    ax.plot([1,2,3], label='label')
-    ax.plot([2,2,2], 'o', label='dots')
+    ax.plot([1, 2, 3], label='label')
+    ax.plot([2, 2, 2], 'o', label='dots')
     ax.legend().set_visible(True)
     _assert_output_equal(fake_renderer_output(fig, FullFakeRenderer),
                          """
@@ -200,8 +198,8 @@ def test_legend_dots():
                          closing figure
                          """)
 
+
 def test_blended():
     fig, ax = plt.subplots()
     ax.axvline(0)
     assert_warns(UserWarning, fake_renderer_output, fig, FakeRenderer)
-    

--- a/mplexporter/tests/test_utils.py
+++ b/mplexporter/tests/test_utils.py
@@ -1,5 +1,5 @@
 from numpy.testing import assert_allclose, assert_equal
-import matplotlib.pyplot as plt
+from . import plt
 from .. import utils
 
 
@@ -9,3 +9,26 @@ def test_path_data():
 
     assert_allclose(vertices.shape, (25, 2))
     assert_equal(codes, ['M', 'C', 'C', 'C', 'C', 'C', 'C', 'C', 'C', 'Z'])
+
+
+def test_linestyle():
+    linestyles = {'solid': 'none', '-': 'none',
+                  'dashed': '6,6', '--': '6,6',
+                  'dotted': '2,2', ':': '2,2',
+                  'dashdot': '4,4,2,4', '-.': '4,4,2,4',
+                  '': None, 'None': None}
+
+    for ls, result in linestyles.items():
+        line, = plt.plot([1, 2, 3], linestyle=ls)
+        assert_equal(utils.get_dasharray(line), result)
+
+
+def test_axis_w_fixed_formatter():
+    positions, labels = [0, 1, 10], ['A','B','C']
+
+    plt.xticks(positions, labels)
+    props = utils.get_axis_properties(plt.gca().xaxis)
+
+    assert_equal(props['tickvalues'], positions)
+    assert_equal(props['tickformat'], labels)
+

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -27,20 +27,20 @@ def color_to_hex(color):
         return '#{0:02X}{1:02X}{2:02X}'.format(*(int(255 * c) for c in rgb))
 
 
-def many_to_one(input_dict):
+def _many_to_one(input_dict):
     """Convert a many-to-one mapping to a one-to-one mapping"""
     return dict((key, val)
                 for keys, val in input_dict.items()
                 for key in keys)
 
-LINESTYLES = many_to_one({('solid', '-', (None, None)): "10,0",
-                          ('dashed', '--'): "6,6",
-                          ('dotted', ':'): "2,2",
-                          ('dashdot', '-.'): "4,4,2,4",
-                          ('', ' ', 'None', 'none'): "none"})
+LINESTYLES = _many_to_one({('solid', '-', (None, None)): 'none',
+                           ('dashed', '--'): "6,6",
+                           ('dotted', ':'): "2,2",
+                           ('dashdot', '-.'): "4,4,2,4",
+                           ('', ' ', 'None', 'none'): None})
 
 
-def get_dasharray(obj, i=None):
+def get_dasharray(obj):
     """Get an SVG dash array for the given matplotlib linestyle
 
     Parameters
@@ -48,7 +48,6 @@ def get_dasharray(obj, i=None):
     obj : matplotlib object
         The matplotlib line or path object, which must have a get_linestyle()
         method which returns a valid matplotlib line code
-    i : integer (optional)
 
     Returns
     -------
@@ -59,14 +58,11 @@ def get_dasharray(obj, i=None):
         return ','.join(map(str, obj._dashSeq))
     else:
         ls = obj.get_linestyle()
-        if i is not None:
-            ls = ls[i]
-
-        dasharray = LINESTYLES.get(ls, None)
-        if dasharray is None:
-            warnings.warn("dash style '{0}' not understood: "
-                          "defaulting to solid.".format(ls))
-            dasharray = LINESTYLES['-']
+        dasharray = LINESTYLES.get(ls, 'not found')
+        if dasharray == 'not found':
+            warnings.warn("line style '{0}' not understood: "
+                          "defaulting to solid line.".format(ls))
+            dasharray = LINESTYLES['solid']
         return dasharray
 
 
@@ -178,6 +174,7 @@ def get_text_style(text):
     style['color'] = color_to_hex(text.get_color())
     style['halign'] = text.get_horizontalalignment()  # left, center, right
     style['valign'] = text.get_verticalalignment()  # baseline, center, top
+    style['malign'] = text._multialignment # text alignment when '\n' in text
     style['rotation'] = text.get_rotation()
     style['zorder'] = text.get_zorder()
     return style
@@ -213,6 +210,8 @@ def get_axis_properties(axis):
     formatter = axis.get_major_formatter()
     if isinstance(formatter, ticker.NullFormatter):
         props['tickformat'] = ""
+    elif isinstance(formatter, ticker.FixedFormatter):
+        props['tickformat'] = list(formatter.seq)
     elif not any(label.get_visible() for label in axis.get_ticklabels()):
         props['tickformat'] = ""
     else:
@@ -248,7 +247,7 @@ def get_grid_style(axis):
                     dasharray=dasharray,
                     alpha=alpha)
     else:
-        return {"gridOn":False}
+        return {"gridOn": False}
 
 
 def get_figure_properties(fig):
@@ -328,7 +327,7 @@ def get_legend_properties(ax, legend):
     handles, labels = ax.get_legend_handles_labels()
     visible = legend.get_visible()
     return {'handles': handles, 'labels': labels, 'visible': visible}
-    
+
 
 def image_to_base64(image):
     """


### PR DESCRIPTION
In order to make twinx and/or twiny working with the latest version of matplotlib, we need to pass on the visibility of the patch. For completeness, I also pass on the visibility of the axis given that twinx/twiny also modifies this.  
