### PR TITLE
utils.get_axes_properties: ValueError for unknown scale is buggy

### DIFF
--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -292,7 +292,7 @@ def get_axes_properties(ax):
 
         if scale not in ['date', 'linear', 'log']:
             raise ValueError("Unknown axis scale: "
-                             "{0}".format(axis[axname].get_scale()))
+                             "{0}".format(axis.get_scale()))
 
         props[axname + 'scale'] = scale
         props[axname + 'lim'] = lim


### PR DESCRIPTION
The `ValueError` that gets raised for unknown scales should reference just `axis`, not `axis[axname]`. This one-liner fixes the exception call. 
