### PR TITLE
Fix for bool on ndarray

### DIFF
--- a/mplexporter/renderers/base.py
+++ b/mplexporter/renderers/base.py
@@ -189,7 +189,7 @@ class Renderer(object):
         """Build an iterator over the elements of the path collection"""
         N = max(len(paths), len(offsets))
 
-        if not path_transforms:
+        if path_transforms is None:
             path_transforms = [np.eye(3)]
 
         edgecolor = styles['edgecolor']


### PR DESCRIPTION
I've been using mplexporter in [mplleaflet](http://github.com/jwass/mplleaflet).

This fixes one of the tests that fails in matplotlib 1.4 as pointed out in #29 - and now causes an mplleaflet crash. see jwass/mplleaflet#10
Rather than stand up Travis config file, I figured I'd let the other discussions, the MEP, bear out and instead tested this to ensure that the tests still pass for matplotlib 1.3 with this applied.

Let me know if there are any issues.
