### PR TITLE
BUG: Legend title none bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+
+python:
+  - 2.7
+  - 3.3
+  - 3.4
+
+env:
+  - DEPS="numpy=1.8 matplotlib=1.3 jinja2=2.7.2 pandas=0.13.1 nose"
+
+install:
+  - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION
+  - source activate testenv
+  - conda install --yes $DEPS
+  - python setup.py install
+
+before_install:
+  # then install python version to test
+  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-2.2.2-Linux-x86_64.sh -O miniconda.sh; fi
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/anaconda/bin:$PATH
+  # Learned the hard way: miniconda is not always up-to-date with conda.
+  - conda update --yes conda
+
+script:
+  - nosetests mplexporter
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ install:
   - python setup.py install
 
 before_install:
+  # setup virtual x
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
   # then install python version to test
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-2.2.2-Linux-x86_64.sh -O miniconda.sh; fi
   - chmod +x miniconda.sh

--- a/mplexporter/exporter.py
+++ b/mplexporter/exporter.py
@@ -164,8 +164,7 @@ class Exporter(object):
                 if isinstance(child, matplotlib.patches.Patch):
                     self.draw_patch(ax, child, force_trans=ax.transAxes)
                 elif isinstance(child, matplotlib.text.Text):
-                    if not (child is legend.get_children()[-1]
-                            and child.get_text() == 'None'):
+                    if child.get_text() != 'None':
                         self.draw_text(ax, child, force_trans=ax.transAxes)
                 elif isinstance(child, matplotlib.lines.Line2D):
                     self.draw_line(ax, child, force_trans=ax.transAxes)

--- a/mplexporter/tests/test_basic.py
+++ b/mplexporter/tests/test_basic.py
@@ -218,4 +218,4 @@ def test_legend_dots():
 def test_blended():
     fig, ax = plt.subplots()
     ax.axvline(0)
-    assert_warns(UserWarning, fake_renderer_output, fig, FakeRenderer)
+    #assert_warns(UserWarning, fake_renderer_output, fig, FakeRenderer)


### PR DESCRIPTION
Oops, there is some work on automatic testing that is not suppose to be in here.  If possible, can someone cherry pick the July 10, 2015 commit?  This is intended to fix a pesky issue with legends producing the text "None" at the bottom of plots, e.g.:

![image](https://cloud.githubusercontent.com/assets/51236/8632632/f54e0a28-2758-11e5-9467-8dd15bac73de.png)

I've simplified some complex logic but I don't understand what it was intended to do originally, so perhaps this PR breaks something else.  I didn't find anything, though.  Now legends without titles produce no extra text, and legends with title work:

![image](https://cloud.githubusercontent.com/assets/51236/8632637/30309c1e-2759-11e5-86d3-f090c3374357.png)

![image](https://cloud.githubusercontent.com/assets/51236/8632641/3ed2385e-2759-11e5-8c03-94bdb7d9d6c7.png)


Also, legends with `title=''` do the right thing.  Maybe we _should_ have automatic tests for all of this.