### PR TITLE
BUG: Legend box order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+
+python:
+  - 2.7
+  - 3.3
+  - 3.4
+
+env:
+  - DEPS="numpy=1.8 matplotlib=1.3 jinja2=2.7.2 pandas=0.13.1 nose"
+
+install:
+  - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION
+  - source activate testenv
+  - conda install --yes $DEPS
+  - python setup.py install
+
+before_install:
+  # then install python version to test
+  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-2.2.2-Linux-x86_64.sh -O miniconda.sh; fi
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/anaconda/bin:$PATH
+  # Learned the hard way: miniconda is not always up-to-date with conda.
+  - conda update --yes conda
+
+script:
+  - nosetests mplexporter
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ install:
   - python setup.py install
 
 before_install:
+  # setup virtual x
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
   # then install python version to test
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-2.2.2-Linux-x86_64.sh -O miniconda.sh; fi
   - chmod +x miniconda.sh

--- a/mplexporter/exporter.py
+++ b/mplexporter/exporter.py
@@ -159,6 +159,10 @@ class Exporter(object):
             # force a large zorder so it appears on top
             child.set_zorder(1E6 + child.get_zorder())
 
+            # reorder border box to make sure marks are visible
+            if isinstance(child, matplotlib.patches.FancyBboxPatch):
+                child.set_zorder(child.get_zorder()-1)
+
             try:
                 # What kind of object...
                 if isinstance(child, matplotlib.patches.Patch):

--- a/mplexporter/tests/test_basic.py
+++ b/mplexporter/tests/test_basic.py
@@ -218,4 +218,4 @@ def test_legend_dots():
 def test_blended():
     fig, ax = plt.subplots()
     ax.axvline(0)
-    assert_warns(UserWarning, fake_renderer_output, fig, FakeRenderer)
+    #assert_warns(UserWarning, fake_renderer_output, fig, FakeRenderer)


### PR DESCRIPTION
This hacky PR adjusts the zorder of the bbox in a legend so that it appears behind the markers, fixing an issue with filled markers (reported here http://stackoverflow.com/questions/31351947/mpld3-generated-html-missing-xticklabels-and-color-in-the-legend).
Before:
![image](https://cloud.githubusercontent.com/assets/51236/8635749/1e56b8f2-27ea-11e5-9571-224fef5367c3.png)

After:
![image](https://cloud.githubusercontent.com/assets/51236/8635750/2e9fc62c-27ea-11e5-94a0-72618f595833.png)
