### PR TITLE
Fix for 'conda: command not found'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   # then install python version to test
   - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
-  - ./miniconda.sh -b
+  - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   # Learned the hard way: miniconda is not always up-to-date with conda.
   - conda update --yes conda


### PR DESCRIPTION
Fix for build failure in PR #45.

Follows http://conda.pydata.org/docs/travis.html.