### PR TITLE
fix for u’default’ drawstyle in python2

### DIFF
--- a/mplexporter/exporter.py
+++ b/mplexporter/exporter.py
@@ -184,12 +184,8 @@ class Exporter(object):
                                                    force_trans=force_trans)
         linestyle = utils.get_line_style(line)
         if (linestyle['dasharray'] is None
-                and linestyle['drawstyle'] is 'default'):
+                and linestyle['drawstyle'] == 'default'):
             linestyle = None
-        elif linestyle['dasharray'] is None:
-            #fix for matplotlib sometimes returning unicode in python2
-            if linestyle['drawstyle'].encode('UTF-8') == 'default':
-                linestyle = None
         markerstyle = utils.get_marker_style(line)
         if (markerstyle['marker'] in ['None', 'none', None]
                 or markerstyle['markerpath'][0].size == 0):

--- a/mplexporter/exporter.py
+++ b/mplexporter/exporter.py
@@ -186,6 +186,10 @@ class Exporter(object):
         if (linestyle['dasharray'] is None
                 and linestyle['drawstyle'] is 'default'):
             linestyle = None
+        elif linestyle['dasharray'] is None:
+            #fix for matplotlib sometimes returning unicode in python2
+            if linestyle['drawstyle'].encode('UTF-8') == 'default':
+                linestyle = None
         markerstyle = utils.get_marker_style(line)
         if (markerstyle['marker'] in ['None', 'none', None]
                 or markerstyle['markerpath'][0].size == 0):


### PR DESCRIPTION
In some cases matplotlib seems to be returning u’default’ from Line2D.get_drawstyle()
This fix adds an additional check after casting to UTF-8 rather than using a u’default’ string which would break in python3.0/3.1

fixes mpld3/mpld3#367
