### PR TITLE
Keep alpha channel in RGBA colors

### DIFF
--- a/mplexporter/renderers/base.py
+++ b/mplexporter/renderers/base.py
@@ -265,8 +265,8 @@ class Renderer(object):
             # This is a hack:
             if path_coordinates == "figure":
                 path_coordinates = "points"
-            style = {"edgecolor": utils.color_to_hex(ec),
-                     "facecolor": utils.color_to_hex(fc),
+            style = {"edgecolor": utils.export_color(ec),
+                     "facecolor": utils.export_color(fc),
                      "edgewidth": lw,
                      "dasharray": "10,0",
                      "alpha": styles['alpha'],

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -23,8 +23,9 @@ def color_to_hex(color):
     if color is None or colorConverter.to_rgba(color)[3] == 0:
         return 'none'
     else:
-        rgb = colorConverter.to_rgb(color)
-        return '#{0:02X}{1:02X}{2:02X}'.format(*(int(255 * c) for c in rgb))
+        c = colorConverter.to_rgba(color)
+        return "rgba(" + ", ".join(str(int(np.round(val * 255)))
+                                        for val in c[:3])+', '+str(c[3])+")"
 
 
 def _many_to_one(input_dict):

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -22,6 +22,9 @@ def export_color(color):
     """Convert matplotlib color code to hex color code"""
     if color is None or colorConverter.to_rgba(color)[3] == 0:
         return 'none'
+    elif colorConverter.to_rgba(color)[3] == 1:
+        rgb = colorConverter.to_rgb(color)
+        return '#{0:02X}{1:02X}{2:02X}'.format(*(int(255 * c) for c in rgb))
     else:
         c = colorConverter.to_rgba(color)
         return "rgba(" + ", ".join(str(int(np.round(val * 255)))

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -18,7 +18,7 @@ from matplotlib.transforms import Affine2D
 from matplotlib import ticker
 
 
-def color_to_hex(color):
+def export_color(color):
     """Convert matplotlib color code to hex color code"""
     if color is None or colorConverter.to_rgba(color)[3] == 0:
         return 'none'
@@ -118,9 +118,9 @@ def get_path_style(path, fill=True):
     style['alpha'] = path.get_alpha()
     if style['alpha'] is None:
         style['alpha'] = 1
-    style['edgecolor'] = color_to_hex(path.get_edgecolor())
+    style['edgecolor'] = export_color(path.get_edgecolor())
     if fill:
-        style['facecolor'] = color_to_hex(path.get_facecolor())
+        style['facecolor'] = export_color(path.get_facecolor())
     else:
         style['facecolor'] = 'none'
     style['edgewidth'] = path.get_linewidth()
@@ -135,7 +135,7 @@ def get_line_style(line):
     style['alpha'] = line.get_alpha()
     if style['alpha'] is None:
         style['alpha'] = 1
-    style['color'] = color_to_hex(line.get_color())
+    style['color'] = export_color(line.get_color())
     style['linewidth'] = line.get_linewidth()
     style['dasharray'] = get_dasharray(line)
     style['zorder'] = line.get_zorder()
@@ -150,8 +150,8 @@ def get_marker_style(line):
     if style['alpha'] is None:
         style['alpha'] = 1
 
-    style['facecolor'] = color_to_hex(line.get_markerfacecolor())
-    style['edgecolor'] = color_to_hex(line.get_markeredgecolor())
+    style['facecolor'] = export_color(line.get_markerfacecolor())
+    style['edgecolor'] = export_color(line.get_markeredgecolor())
     style['edgewidth'] = line.get_markeredgewidth()
 
     style['marker'] = line.get_marker()
@@ -173,7 +173,7 @@ def get_text_style(text):
     if style['alpha'] is None:
         style['alpha'] = 1
     style['fontsize'] = text.get_size()
-    style['color'] = color_to_hex(text.get_color())
+    style['color'] = export_color(text.get_color())
     style['halign'] = text.get_horizontalalignment()  # left, center, right
     style['valign'] = text.get_verticalalignment()  # baseline, center, top
     style['malign'] = text._multialignment # text alignment when '\n' in text
@@ -241,7 +241,7 @@ def get_axis_properties(axis):
 def get_grid_style(axis):
     gridlines = axis.get_gridlines()
     if axis._gridOnMajor and len(gridlines) > 0:
-        color = color_to_hex(gridlines[0].get_color())
+        color = export_color(gridlines[0].get_color())
         alpha = gridlines[0].get_alpha()
         dasharray = get_dasharray(gridlines[0])
         return dict(gridOn=True,
@@ -259,7 +259,7 @@ def get_figure_properties(fig):
 
 
 def get_axes_properties(ax):
-    props = {'axesbg': color_to_hex(ax.patch.get_facecolor()),
+    props = {'axesbg': export_color(ax.patch.get_facecolor()),
              'axesbgalpha': ax.patch.get_alpha(),
              'bounds': ax.get_position().bounds,
              'dynamic': ax.get_navigate(),

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -19,7 +19,7 @@ from matplotlib import ticker
 
 
 def export_color(color):
-    """Convert matplotlib color code to hex color code"""
+    """Convert matplotlib color code to hex color or RGBA color"""
     if color is None or colorConverter.to_rgba(color)[3] == 0:
         return 'none'
     elif colorConverter.to_rgba(color)[3] == 1:


### PR DESCRIPTION
Hi,

I noticed that some of my plots looked less pretty in D3 than in matplotlib since mpld3 ignored the alpha channel in RGBA colors. I now made a simple change to the `color_to_hex` function in mplexporter that, instead of converting colors to a format like `#aabbcc`, converts them to a format like `rgba(255, 255, 255, 0.5)`. This is supported by all major browsers (and I checked that it works).

If this PR is merged, I can also adapt the unit tests in mpld3 to the change.
