### PR TITLE
Update for matplotlib 2.2.2 compatibility

### DIFF
--- a/mplexporter/tests/test_basic.py
+++ b/mplexporter/tests/test_basic.py
@@ -213,9 +213,9 @@ def test_legend_dots():
                          opening legend
                          draw line with 2 points
                          draw text 'label' None
-                         draw 2 markers
+                         draw 1 markers
                          draw text 'dots' None
-                         draw path with 4 vertices
+                         draw path with 13 vertices
                          closing legend
                          closing axes
                          closing figure

--- a/mplexporter/tests/test_basic.py
+++ b/mplexporter/tests/test_basic.py
@@ -177,7 +177,7 @@ def test_image():
                          """
                          opening figure
                          opening axes
-                         draw image of size 1240 
+                         draw image of size 1240
                          closing axes
                          closing figure
                          """)

--- a/mplexporter/tests/test_utils.py
+++ b/mplexporter/tests/test_utils.py
@@ -13,9 +13,9 @@ def test_path_data():
 
 def test_linestyle():
     linestyles = {'solid': 'none', '-': 'none',
-                  'dashed': '6,6', '--': '6,6',
-                  'dotted': '2,2', ':': '2,2',
-                  'dashdot': '4,4,2,4', '-.': '4,4,2,4',
+                  'dashed': '3.7,1.6', '--': '3.7,1.6',
+                  'dotted': '1.0,1.65', ':': '1.0,1.65',
+                  'dashdot': '6.4,1.6,1.0,1.6', '-.': '6.4,1.6,1.0,1.6',
                   '': None, 'None': None}
 
     for ls, result in linestyles.items():

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -54,8 +54,8 @@ def get_dasharray(obj):
     dasharray : string
         The HTML/SVG dasharray code associated with the object.
     """
-    if obj.__dict__.get('_dashSeq', None) is not None:
-        return ','.join(map(str, obj._dashSeq))
+    if obj.__dict__.get('_us_dashSeq', None) is not None:
+        return ','.join(map(str, obj._us_dashSeq))
     else:
         ls = obj.get_linestyle()
         dasharray = LINESTYLES.get(ls, 'not found')

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -54,6 +54,7 @@ def get_dasharray(obj):
     dasharray : string
         The HTML/SVG dasharray code associated with the object.
     """
+    # NOTE: _us_dashSeq is an undocumented property and is liable to change.
     if obj.__dict__.get('_us_dashSeq', None) is not None:
         return ','.join(map(str, obj._us_dashSeq))
     else:


### PR DESCRIPTION
There were two things updated in MPL.

(1) MPL 2.2.2 draws legends differently, so I have changed the test to reflect
  this.
(2) The undocumented property line._dashSeq has changed. There is now a
  non-scaled version which must be used. Additionally, the default values
  are different. I have changed both the tests and the function in
  `utils.py`.

I've only run the tests, so if there are any other ways for me to test and confirm
that `mplexporter` works with `matplotlib==2.2.2`, please let me know!

I'm still getting familiar with the project, so feel free to tell me if something
should be done differently.

Note: I assume the build will fail as it uses MPL 1.5.x.

I've attached screenshots of point (1).

![screen shot 2018-04-26 at 15 59 25](https://user-images.githubusercontent.com/291640/39379134-a72bd06e-4a5a-11e8-8fc1-06617076e686.png)
![screen shot 2018-04-26 at 16 04 46](https://user-images.githubusercontent.com/291640/39379135-a8429334-4a5a-11e8-9861-cfcb2be1d499.png)
