### PR TITLE
Fix 2 Matplotlib errors

### DIFF
--- a/mplexporter/exporter.py
+++ b/mplexporter/exporter.py
@@ -262,16 +262,12 @@ class Exporter(object):
                   'alpha': collection._alpha,
                   'zorder': collection.get_zorder()}
 
-        offset_dict = {"data": "before",
-                       "screen": "after"}
-        offset_order = offset_dict[collection.get_offset_position()]
-
         self.renderer.draw_path_collection(paths=processed_paths,
                                            path_coordinates=path_coords,
                                            path_transforms=path_transforms,
                                            offsets=offsets,
                                            offset_coordinates=offset_coords,
-                                           offset_order=offset_order,
+                                           offset_order="after",
                                            styles=styles,
                                            mplobj=collection)
 

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -260,7 +260,7 @@ def get_axis_properties(axis):
 
 def get_grid_style(axis):
     gridlines = axis.get_gridlines()
-    if axis._gridOnMajor and len(gridlines) > 0:
+    if axis._major_tick_kw['gridOn'] and len(gridlines) > 0:
         color = export_color(gridlines[0].get_color())
         alpha = gridlines[0].get_alpha()
         dasharray = get_dasharray(gridlines[0])


### PR DESCRIPTION
Matplotlib recently removed the `_gridOnMajor` attributes, source: https://github.com/matplotlib/matplotlib/pull/18769

Additionally `collection.get_offset_position()` has been [deprecated](https://matplotlib.org/api/collections_api.html#matplotlib.collections.Collection.get_offset_position) and the default behaviour is now only `screen`, source: https://matplotlib.org/api/collections_api.html#matplotlib.collections.Collection