### PR TITLE
Replace deprecated LooseVersion

### DIFF
--- a/mplexporter/renderers/base.py
+++ b/mplexporter/renderers/base.py
@@ -1,7 +1,7 @@
 import warnings
 import itertools
 from contextlib import contextmanager
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import numpy as np
 import matplotlib as mpl
@@ -193,7 +193,7 @@ class Renderer(object):
 
         # Before mpl 1.4.0, path_transform can be a false-y value, not a valid
         # transformation matrix.
-        if LooseVersion(mpl.__version__) < LooseVersion('1.4.0'):
+        if Version(mpl.__version__) < Version('1.4.0'):
             if path_transforms is None:
                 path_transforms = [np.eye(3)]
 


### PR DESCRIPTION
This PR fix deprecation warning generated by LooseVersion from `distutils.version`.
```
[...]/lib/python3.10/site-packages/mpld3/mplexporter/renderers/base.py:4: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils.version import LooseVersion
```