### PR TITLE
Support FuncFormatter

### DIFF
--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -235,6 +235,9 @@ def get_axis_properties(axis):
     elif isinstance(formatter, ticker.FixedFormatter):
         props['tickformat'] = list(formatter.seq)
         props['tickformat_formatter'] = "fixed"
+    elif isinstance(formatter, ticker.FuncFormatter):
+        props['tickformat'] = [formatter(value) for value in props['tickvalues']]
+        props['tickformat_formatter'] = "func"
     elif not any(label.get_visible() for label in axis.get_ticklabels()):
         props['tickformat'] = ""
     else:

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -235,7 +235,7 @@ def get_axis_properties(axis):
     elif isinstance(formatter, ticker.FixedFormatter):
         props['tickformat'] = list(formatter.seq)
         props['tickformat_formatter'] = "fixed"
-    elif isinstance(formatter, ticker.FuncFormatter):
+    elif isinstance(formatter, ticker.FuncFormatter) and props['tickvalues']:
         props['tickformat'] = [formatter(value) for value in props['tickvalues']]
         props['tickformat_formatter'] = "func"
     elif not any(label.get_visible() for label in axis.get_ticklabels()):


### PR DESCRIPTION
This should, together with a small change to the mpld3 JavaScript, address https://github.com/mpld3/mpld3/issues/532.

The tick formatter in use by Matplotlib for the mpld3 tests is [matplotlib.ticker.FuncFormatter](https://matplotlib.org/stable/api/ticker_api.html#matplotlib.ticker.FuncFormatter). This is not currently handled by the exporter, so the tick labels were not getting stored in the properties dictionary.