### PR TITLE
Fix broken scatter/fill_between in log-scale axis

### DIFF
--- a/mplexporter/exporter.py
+++ b/mplexporter/exporter.py
@@ -177,9 +177,9 @@ class Exporter(object):
                     self.draw_collection(ax, child,
                                          force_offsettrans=ax.transAxes)
                 else:
-                    warnings.warn("Legend element %s not impemented" % child)
+                    warnings.warn("Legend element %s not implemented" % child)
             except NotImplementedError:
-                warnings.warn("Legend element %s not impemented" % child)
+                warnings.warn("Legend element %s not implemented" % child)
 
     def draw_line(self, ax, line, force_trans=None):
         """Process a matplotlib line and call renderer.draw_line"""

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -344,7 +344,7 @@ def get_axes_properties(ax):
 
 def iter_all_children(obj, skipContainers=False):
     """
-    Returns an iterator over all childen and nested children using
+    Returns an iterator over all children and nested children using
     obj's get_children() method
 
     if skipContainers is true, only childless objects are returned.


### PR DESCRIPTION
I did try to fix this myself, but failed. So I asked Codex (gpt5-high) and it found the issue and proposed this fix, which I verified works, and I streamlined its code a bit.

Here's what it had to say:

> - `mplexporter/mplexporter/exporter.py:6-275` now imports `numpy/mpath` and routes collections through `_prepare_collection_data`, which preserves data-space vertices/offsets whenever a non-affine `ax.transData` branch is
>    involved (log scales, semilog, etc.). As a result, `fill_between`, `scatter`, and other `PathCollections` on log axes export with `pathcoordinates/offsetcoordinates == 'data'`, so the rendered polygons obey zooming/panning.
> - `mpld3/tests/test_elements.py:76-103` adds regression tests for both `fill_between` and `scatter` on logarithmic axes to guard against future regressions in the exported coordinate system.

Here's an example of my app before this fix:
<img width="760" height="664" alt="image" src="https://github.com/user-attachments/assets/2e91ce3c-a21e-4c61-868b-72803d2a6550" />


And after this fix:
<img width="683" height="667" alt="image" src="https://github.com/user-attachments/assets/3c614ce0-1eb3-4df1-9ae2-047d8333d8e0" />
