### PR TITLE
Also export minor grid

### DIFF
--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -233,6 +233,10 @@ def get_axis_properties(axis):
     props['nticks'] = len(tick_locs)
     props['tickvalues'] = tick_locs if isinstance(locator, ticker.FixedLocator) else None
 
+    minor_locator = axis.get_minor_locator()
+    props['minor_tickvalues'] = list(axis.get_minorticklocs()) if minor_locator else None
+    props['minorticklength'] = axis._minor_tick_kw.get('size', None)
+
     # Find tick formats
     props['tickformat_formatter'] = ""
     formatter = axis.get_major_formatter()
@@ -279,6 +283,7 @@ def get_axis_properties(axis):
 
     # Get associated grid
     props['grid'] = get_grid_style(axis)
+    props['minor_grid'] = get_grid_style(axis, which='minor')
 
     # get axis visibility
     props['visible'] = axis.get_visible()
@@ -286,20 +291,23 @@ def get_axis_properties(axis):
     return props
 
 
-def get_grid_style(axis):
-    gridlines = axis.get_gridlines()
-    if axis._major_tick_kw['gridOn'] and len(gridlines) > 0:
-        color = export_color(gridlines[0].get_color())
-        alpha = gridlines[0].get_alpha()
-        dasharray = get_dasharray(gridlines[0])
-        linewidth = gridlines[0].get_linewidth()
-        return dict(gridOn=True,
-                    color=color,
-                    dasharray=dasharray,
-                    linewidth=linewidth,
-                    alpha=alpha)
-    else:
+def get_grid_style(axis, which='major'):
+    tick_kw = axis._minor_tick_kw if which == 'minor' else axis._major_tick_kw
+
+    if not tick_kw.get('gridOn'):
         return {"gridOn": False}
+
+    rc = matplotlib.rcParams
+    color = export_color(tick_kw.get('grid_color', tick_kw.get('grid_c', rc['grid.color'])))
+    alpha = tick_kw.get('grid_alpha', rc['grid.alpha'])
+    dasharray = dasharray_from_linestyle(tick_kw.get('grid_linestyle', tick_kw.get('grid_ls', rc['grid.linestyle'])))
+    linewidth = tick_kw.get('grid_linewidth', tick_kw.get('grid_lw', rc['grid.linewidth']))
+
+    return dict(gridOn=True,
+                color=color,
+                dasharray=dasharray,
+                linewidth=linewidth,
+                alpha=alpha)
 
 
 def get_figure_properties(fig):


### PR DESCRIPTION
(note: builds on top of https://github.com/mpld3/mplexporter/pull/72/files so contains that commit, which I'll make disappear after merge+rebase)

This will allow to render both major and minor gridlines in mpld3, which
fixes the following issue: https://github.com/mpld3/mpld3/issues/527

As per usual, disclaimer that I co-developed this with gpt-5.1-codex,
having it figure out the issues and give implementation recommendations,
with me testing, verifying, and tidying up the code.

Here's what it has to say, especially wrt the change in API call:

- include minor tick values/length and minor grid style in axis props so minor ticks/grids render in mpld3
- read grid color/linewidth/linestyle from tick kwargs (and rcParams fallback) instead of inspecting gridlines[0], avoiding the get_gridlines(which=…) API that isn’t available on matplotlib 3.10”

Rationale for the kw/rc approach:
`Axis.get_gridlines()` doesn’t accept `which` on matplotlib 3.10, so probing `gridlines[0]` for minor/major fails. Pulling style from the tick keyword dict (which matplotlib populates with `grid_*` fields when you call `ax.grid(...)`) plus
`rcParams` defaults gives the same style without needing `get_gridlines(which=…)`, keeping compatibility and matching user-set grid styles.

(I verified, indeed get_gridlines does not allow specifying which ones - seems like an omission in matplotlib API to me)

Screenshot of it working, blue are the minor ticks. Note the minor tick labels are not yet shown, I'll work on that later - maybe updating this PR in-place, or with a new one on top, depending on how simple/complex it is.
<img width="586" height="286" alt="image" src="https://github.com/user-attachments/assets/8f537de1-8886-4f00-b350-ab972484611b" />
