### PR TITLE
Make FuncFormatter work with non-fixed locator

### DIFF
--- a/mplexporter/tests/__init__.py
+++ b/mplexporter/tests/__init__.py
@@ -1,9 +1,6 @@
 import os
 
-MPLBE = os.environ.get('MPLBE', 'Agg')
-
-if MPLBE:
-    import matplotlib
+import matplotlib
+if MPLBE := os.environ.get('MPLBE', 'Agg'):
     matplotlib.use(MPLBE)
-
 import matplotlib.pyplot as plt

--- a/mplexporter/tests/test_utils.py
+++ b/mplexporter/tests/test_utils.py
@@ -1,5 +1,5 @@
-from numpy.testing import assert_allclose, assert_equal
-from . import plt
+from numpy.testing import assert_, assert_allclose, assert_equal
+from . import plt, matplotlib
 from .. import utils
 
 
@@ -33,3 +33,23 @@ def test_axis_w_fixed_formatter():
     # NOTE: Issue #471
     # assert_equal(props['tickformat'], labels)
 
+
+def test_funcformatter_exports_major_ticklabels():
+    # Test both log and normal cases:
+    for scale, x, y in [
+        ("linear", [0, 1], [0, 1]),
+        ("log", [1, 10, 100], [0, 1, 2]),
+    ]:
+        fig, ax = plt.subplots()
+        ax.set_xscale(scale)
+        ax.plot([1, 10, 100], [0, 1, 2])
+        ax.xaxis.set_major_formatter(matplotlib.ticker.FuncFormatter(lambda x, pos: f"t{pos}"))
+
+        props = utils.get_axis_properties(ax.xaxis)
+        plt.close(fig)
+
+        assert_equal(props["scale"], scale)
+        assert_equal(props["tickformat_formatter"], "func")
+        assert_(props["tickvalues"] is not None)
+        assert_equal(len(props["tickvalues"]), len(props["tickformat"]))
+        assert_equal(props["tickformat"][:3], ["t0", "t1", "t2"])

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -212,6 +212,10 @@ def get_axis_properties(axis):
     else:
         props['tickvalues'] = None
 
+    minor_locator = axis.get_minor_locator()
+    props['minor_tickvalues'] = list(axis.get_minorticklocs()) if minor_locator else None
+    props['minorticklength'] = axis._minor_tick_kw.get('size', None)
+
     # Find tick formats
     props['tickformat_formatter'] = ""
     formatter = axis.get_major_formatter()
@@ -255,6 +259,7 @@ def get_axis_properties(axis):
 
     # Get associated grid
     props['grid'] = get_grid_style(axis)
+    props['minor_grid'] = get_grid_style(axis, which='minor')
 
     # get axis visibility
     props['visible'] = axis.get_visible()
@@ -262,20 +267,23 @@ def get_axis_properties(axis):
     return props
 
 
-def get_grid_style(axis):
-    gridlines = axis.get_gridlines()
-    if axis._major_tick_kw['gridOn'] and len(gridlines) > 0:
-        color = export_color(gridlines[0].get_color())
-        alpha = gridlines[0].get_alpha()
-        dasharray = get_dasharray(gridlines[0])
-        linewidth = gridlines[0].get_linewidth()
-        return dict(gridOn=True,
-                    color=color,
-                    dasharray=dasharray,
-                    linewidth=linewidth,
-                    alpha=alpha)
-    else:
+def get_grid_style(axis, which='major'):
+    tick_kw = axis._minor_tick_kw if which == 'minor' else axis._major_tick_kw
+
+    if not tick_kw.get('gridOn'):
         return {"gridOn": False}
+
+    rc = matplotlib.rcParams
+    color = export_color(tick_kw.get('grid_color', tick_kw.get('grid_c', rc['grid.color'])))
+    alpha = tick_kw.get('grid_alpha', rc['grid.alpha'])
+    dasharray = _dasharray_from_linestyle(tick_kw.get('grid_linestyle', tick_kw.get('grid_ls', rc['grid.linestyle'])))
+    linewidth = tick_kw.get('grid_linewidth', tick_kw.get('grid_lw', rc['grid.linewidth']))
+
+    return dict(gridOn=True,
+                color=color,
+                dasharray=dasharray,
+                linewidth=linewidth,
+                alpha=alpha)
 
 
 def get_figure_properties(fig):

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -203,7 +203,7 @@ def _tick_format_props(formatter, tickvalues, labels):
     if isinstance(formatter, ticker.FixedFormatter):
         return list(formatter.seq), "fixed"
     if isinstance(formatter, ticker.FuncFormatter) and tickvalues:
-        return [formatter(value) for value in tickvalues], "func"
+        return [formatter(value, i) for i, value in enumerate(tickvalues)], "func"
     if not any(label.get_visible() for label in labels):
         return "", ""
     return None, ""
@@ -230,7 +230,7 @@ def get_axis_properties(axis):
     # Use tick values if appropriate
     locator = axis.get_major_locator()
     props['nticks'] = len(locator())
-    if isinstance(locator, ticker.FixedLocator):
+    if isinstance(locator, ticker.FixedLocator) or isinstance(axis.get_major_formatter(), ticker.FuncFormatter):
         props['tickvalues'] = list(locator())
     else:
         props['tickvalues'] = None

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -268,9 +268,11 @@ def get_grid_style(axis):
         color = export_color(gridlines[0].get_color())
         alpha = gridlines[0].get_alpha()
         dasharray = get_dasharray(gridlines[0])
+        linewidth = gridlines[0].get_linewidth()
         return dict(gridOn=True,
                     color=color,
                     dasharray=dasharray,
+                    linewidth=linewidth,
                     alpha=alpha)
     else:
         return {"gridOn": False}


### PR DESCRIPTION
Again a note that this is on top of a few previous PRs, so only look at
the last commit, the other ones are duplicates and will disappear upon
merging the other PRs.

The previous fix to make FuncFormatter work, in
https://github.com/mpld3/mplexporter/pull/67/files
and
https://github.com/mpld3/mpld3/commit/e7fa282e72328e25ee2b644c4123606a6e86b9a6
had two issues still: 1) the mpl FuncFormatter API also takes the index as
second argument, which was missing. 2) it exported `tickvalues` only in
the FixedLocator case, so these were missing for non-fixed FuncFormatter
and hence the FuncFormatter codepath, which also requires them to be
present, was never hit with non-fixed locators.

This fixes both. Again, this was figured out and helped with gpt-codex
and my careful review+cleanup. Codex even identified the two original
commits I'm linking above :)