### PR TITLE
Freeze labels for Python-only formatters

### DIFF
--- a/mplexporter/exporter.py
+++ b/mplexporter/exporter.py
@@ -293,6 +293,7 @@ class Exporter(object):
         styles = {'linewidth': collection.get_linewidths(),
                   'facecolor': collection.get_facecolors(),
                   'edgecolor': collection.get_edgecolors(),
+                  'dasharray': utils.get_dasharray_list(collection),
                   'alpha': collection._alpha,
                   'zorder': collection.get_zorder()}
 

--- a/mplexporter/renderers/base.py
+++ b/mplexporter/renderers/base.py
@@ -209,8 +209,12 @@ class Renderer(object):
         if np.size(facecolor) == 0:
             facecolor = ['none']
 
+        dasharray = styles.get('dasharray', None)
+        if dasharray is None or np.size(dasharray) == 0:
+            dasharray = ['none']
+
         elements = [paths, path_transforms, offsets,
-                    edgecolor, styles['linewidth'], facecolor]
+                    edgecolor, styles['linewidth'], facecolor, dasharray]
 
         it = itertools
         return it.islice(py3k.zip(*py3k.map(it.cycle, elements)), N)
@@ -263,7 +267,7 @@ class Renderer(object):
 
         for tup in self._iter_path_collection(paths, path_transforms,
                                               offsets, styles):
-            (path, path_transform, offset, ec, lw, fc) = tup
+            (path, path_transform, offset, ec, lw, fc, da) = tup
             vertices, pathcodes = path
             path_transform = transforms.Affine2D(path_transform)
             vertices = path_transform.transform(vertices)
@@ -273,7 +277,7 @@ class Renderer(object):
             style = {"edgecolor": utils.export_color(ec),
                      "facecolor": utils.export_color(fc),
                      "edgewidth": lw,
-                     "dasharray": "10,0",
+                     "dasharray": da,
                      "alpha": styles['alpha'],
                      "zorder": styles['zorder']}
             self.draw_path(data=vertices, coordinates=path_coordinates,

--- a/mplexporter/renderers/base.py
+++ b/mplexporter/renderers/base.py
@@ -158,6 +158,11 @@ class Renderer(object):
         if markerstyle is not None:
             self.draw_markers(data, coordinates, markerstyle, label, mplobj)
 
+    def draw_figure_text(self, text, position, coordinates, style,
+                         text_type=None, mplobj=None):
+        """Figure-level text; renderers that care can override."""
+        pass
+
     def draw_line(self, data, coordinates, style, label, mplobj=None):
         """
         Draw a line. By default, draw the line via the draw_path() command.

--- a/mplexporter/renderers/fake_renderer.py
+++ b/mplexporter/renderers/fake_renderer.py
@@ -35,6 +35,10 @@ class FakeRenderer(Renderer):
     def close_legend(self, legend):
         self.output += "    closing legend\n"
 
+    def draw_figure_text(self, text, position, coordinates, style,
+                         text_type=None, mplobj=None):
+        self.output += "    draw figure text '{0}' {1}\n".format(text, text_type)
+
     def draw_text(self, text, position, coordinates, style,
                   text_type=None, mplobj=None):
         self.output += "    draw text '{0}' {1}\n".format(text, text_type)

--- a/mplexporter/tests/__init__.py
+++ b/mplexporter/tests/__init__.py
@@ -1,9 +1,6 @@
 import os
 
-MPLBE = os.environ.get('MPLBE', 'Agg')
-
-if MPLBE:
-    import matplotlib
+import matplotlib
+if MPLBE := os.environ.get('MPLBE', 'Agg'):
     matplotlib.use(MPLBE)
-
 import matplotlib.pyplot as plt

--- a/mplexporter/tests/test_utils.py
+++ b/mplexporter/tests/test_utils.py
@@ -1,5 +1,5 @@
-from numpy.testing import assert_allclose, assert_equal
-from . import plt
+from numpy.testing import assert_, assert_allclose, assert_equal
+from . import plt, matplotlib
 from .. import utils
 
 
@@ -33,3 +33,23 @@ def test_axis_w_fixed_formatter():
     # NOTE: Issue #471
     # assert_equal(props['tickformat'], labels)
 
+
+def test_funcformatter_exports_major_ticklabels():
+    # Test both log and normal cases:
+    for scale, x, y in [
+        ("linear", [0, 1], [0, 1]),
+        ("log", [1, 10, 100], [0, 1, 2]),
+    ]:
+        fig, ax = plt.subplots()
+        ax.set_xscale(scale)
+        ax.plot([1, 10, 100], [0, 1, 2])
+        ax.xaxis.set_major_formatter(matplotlib.ticker.FuncFormatter(lambda x, pos: f"t{pos}"))
+
+        props = utils.get_axis_properties(ax.xaxis)
+        plt.close(fig)
+
+        assert_equal(props["scale"], scale)
+        assert_equal(props["tickformat_formatter"], "func")
+        assert_(props["tickvalues"] is not None)
+        assert_equal(len(props["tickvalues"]), len(props["tickformat"]))
+        assert_equal(props["tickformat"][:3], ["t0", "t1", "t2"])

--- a/mplexporter/tests/test_utils.py
+++ b/mplexporter/tests/test_utils.py
@@ -53,3 +53,21 @@ def test_funcformatter_exports_major_ticklabels():
         assert_(props["tickvalues"] is not None)
         assert_equal(len(props["tickvalues"]), len(props["tickformat"]))
         assert_equal(props["tickformat"][:3], ["t0", "t1", "t2"])
+
+
+def test_custom_formatter_exports_major_ticklabels():
+    class CustomFormatter(matplotlib.ticker.Formatter):
+        def __call__(self, x, pos=None):
+            return f"c{pos}"
+
+    fig, ax = plt.subplots()
+    ax.plot([0, 1, 2], [0, 1, 2])
+    ax.xaxis.set_major_formatter(CustomFormatter())
+
+    props = utils.get_axis_properties(ax.xaxis)
+    plt.close(fig)
+
+    assert_equal(props["tickformat_formatter"], "func")
+    assert_(props["tickvalues"] is not None)
+    assert_equal(len(props["tickvalues"]), len(props["tickformat"]))
+    assert_equal(props["tickformat"][:3], ["c0", "c1", "c2"])

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -235,6 +235,10 @@ def get_axis_properties(axis):
     else:
         props['tickvalues'] = None
 
+    minor_locator = axis.get_minor_locator()
+    props['minor_tickvalues'] = list(axis.get_minorticklocs()) if minor_locator else None
+    props['minorticklength'] = axis._minor_tick_kw.get('size', None)
+
     # Find tick formats
     props['tickformat_formatter'] = ""
     formatter = axis.get_major_formatter()
@@ -278,6 +282,7 @@ def get_axis_properties(axis):
 
     # Get associated grid
     props['grid'] = get_grid_style(axis)
+    props['minor_grid'] = get_grid_style(axis, which='minor')
 
     # get axis visibility
     props['visible'] = axis.get_visible()
@@ -285,20 +290,23 @@ def get_axis_properties(axis):
     return props
 
 
-def get_grid_style(axis):
-    gridlines = axis.get_gridlines()
-    if axis._major_tick_kw['gridOn'] and len(gridlines) > 0:
-        color = export_color(gridlines[0].get_color())
-        alpha = gridlines[0].get_alpha()
-        dasharray = get_dasharray(gridlines[0])
-        linewidth = gridlines[0].get_linewidth()
-        return dict(gridOn=True,
-                    color=color,
-                    dasharray=dasharray,
-                    linewidth=linewidth,
-                    alpha=alpha)
-    else:
+def get_grid_style(axis, which='major'):
+    tick_kw = axis._minor_tick_kw if which == 'minor' else axis._major_tick_kw
+
+    if not tick_kw.get('gridOn'):
         return {"gridOn": False}
+
+    rc = matplotlib.rcParams
+    color = export_color(tick_kw.get('grid_color', tick_kw.get('grid_c', rc['grid.color'])))
+    alpha = tick_kw.get('grid_alpha', rc['grid.alpha'])
+    dasharray = _dasharray_from_linestyle(tick_kw.get('grid_linestyle', tick_kw.get('grid_ls', rc['grid.linestyle'])))
+    linewidth = tick_kw.get('grid_linewidth', tick_kw.get('grid_lw', rc['grid.linewidth']))
+
+    return dict(gridOn=True,
+                color=color,
+                dasharray=dasharray,
+                linewidth=linewidth,
+                alpha=alpha)
 
 
 def get_figure_properties(fig):

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -291,9 +291,11 @@ def get_grid_style(axis):
         color = export_color(gridlines[0].get_color())
         alpha = gridlines[0].get_alpha()
         dasharray = get_dasharray(gridlines[0])
+        linewidth = gridlines[0].get_linewidth()
         return dict(gridOn=True,
                     color=color,
                     dasharray=dasharray,
+                    linewidth=linewidth,
                     alpha=alpha)
     else:
         return {"gridOn": False}

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -226,7 +226,7 @@ def _tick_format_props(formatter, tickvalues, labels):
     if isinstance(formatter, ticker.FixedFormatter):
         return list(formatter.seq), "fixed"
     if isinstance(formatter, ticker.FuncFormatter) and tickvalues:
-        return [formatter(value) for value in tickvalues], "func"
+        return [formatter(value, i) for i, value in enumerate(tickvalues)], "func"
     if not any(label.get_visible() for label in labels):
         return "", ""
     return None, ""
@@ -253,7 +253,7 @@ def get_axis_properties(axis):
     # Use tick values if appropriate
     locator = axis.get_major_locator()
     props['nticks'] = len(locator())
-    if isinstance(locator, ticker.FixedLocator):
+    if isinstance(locator, ticker.FixedLocator) or isinstance(axis.get_major_formatter(), ticker.FuncFormatter):
         props['tickvalues'] = list(locator())
     else:
         props['tickvalues'] = None

--- a/mplexporter/utils.py
+++ b/mplexporter/utils.py
@@ -209,6 +209,29 @@ def get_text_style(text):
     return style
 
 
+def _tick_format_props(formatter, tickvalues, labels):
+    if isinstance(formatter, ticker.NullFormatter):
+        return "", ""
+    if isinstance(formatter, ticker.StrMethodFormatter):
+        convertor = StrMethodTickFormatterConvertor(formatter)
+        return convertor.output, "str_method"
+    if isinstance(formatter, ticker.PercentFormatter):
+        return {
+            "xmax": formatter.xmax,
+            "decimals": formatter.decimals,
+            "symbol": formatter.symbol,
+        }, "percent"
+    if hasattr(ticker, 'IndexFormatter') and isinstance(formatter, ticker.IndexFormatter):
+        return [text.get_text() for text in labels], "index"
+    if isinstance(formatter, ticker.FixedFormatter):
+        return list(formatter.seq), "fixed"
+    if isinstance(formatter, ticker.FuncFormatter) and tickvalues:
+        return [formatter(value) for value in tickvalues], "func"
+    if not any(label.get_visible() for label in labels):
+        return "", ""
+    return None, ""
+
+
 def get_axis_properties(axis):
     """Return the property dictionary for a matplotlib.Axis instance"""
     props = {}
@@ -238,37 +261,13 @@ def get_axis_properties(axis):
     minor_locator = axis.get_minor_locator()
     props['minor_tickvalues'] = list(axis.get_minorticklocs()) if minor_locator else None
     props['minorticklength'] = axis._minor_tick_kw.get('size', None)
+    props['majorticklength'] = axis._major_tick_kw.get('size', None)
 
     # Find tick formats
-    props['tickformat_formatter'] = ""
-    formatter = axis.get_major_formatter()
-    if isinstance(formatter, ticker.NullFormatter):
-        props['tickformat'] = ""
-    elif isinstance(formatter, ticker.StrMethodFormatter):
-        convertor = StrMethodTickFormatterConvertor(formatter)
-        props['tickformat'] = convertor.output
-        props['tickformat_formatter'] = "str_method"
-    elif isinstance(formatter, ticker.PercentFormatter):
-        props['tickformat'] = {
-            "xmax": formatter.xmax,
-            "decimals": formatter.decimals,
-            "symbol": formatter.symbol,
-        }
-        props['tickformat_formatter'] = "percent"
-    elif hasattr(ticker, 'IndexFormatter') and isinstance(formatter, ticker.IndexFormatter):
-        # IndexFormatter was dropped in matplotlib 3.5
-        props['tickformat'] = [text.get_text() for text in axis.get_ticklabels()]
-        props['tickformat_formatter'] = "index"
-    elif isinstance(formatter, ticker.FixedFormatter):
-        props['tickformat'] = list(formatter.seq)
-        props['tickformat_formatter'] = "fixed"
-    elif isinstance(formatter, ticker.FuncFormatter) and props['tickvalues']:
-        props['tickformat'] = [formatter(value) for value in props['tickvalues']]
-        props['tickformat_formatter'] = "func"
-    elif not any(label.get_visible() for label in axis.get_ticklabels()):
-        props['tickformat'] = ""
-    else:
-        props['tickformat'] = None
+    props['minor_tickformat'], props['minor_tickformat_formatter'] = _tick_format_props(
+        axis.get_minor_formatter(), props['minor_tickvalues'], axis.get_minorticklabels())
+    props['tickformat'], props['tickformat_formatter'] = _tick_format_props(
+        axis.get_major_formatter(), props['tickvalues'], axis.get_ticklabels())
 
     # Get axis scale
     props['scale'] = axis.get_scale()


### PR DESCRIPTION
Note: this PR builds on top of my other PRs. Only the last commit is unique, the leading commits will disappear once #73 - #75 are merged and I rebase.

Treat Python-only formatters (FuncFormatter, and formatter subclasses) as export-time only by precomputing tick labels and exporting tickvalues, so mpld3 doesn’t drop custom formatter subclasses.
This unifies FuncFormatter and non-matplotlib Formatter subclasses under a single check, preserving existing d3 behavior for built-in formatters like Date/Log/Scalar.
Adds tests for custom formatters in both exporter copies.

As a disclaimer, as usual, I noticed an issue in my use, and fixed it together with gpt-5.2-codex, manually reviewing and cleaning up the changes.