### PR TITLE
Also export left and right titles.

### DIFF
--- a/mplexporter/exporter.py
+++ b/mplexporter/exporter.py
@@ -141,11 +141,16 @@ class Exporter(object):
                 self.draw_line(ax, line)
             for text in ax.texts:
                 self.draw_text(ax, text)
-            for (text, ttp) in zip([ax.xaxis.label, ax.yaxis.label, ax.title],
-                                   ["xlabel", "ylabel", "title"]):
-                if(hasattr(text, 'get_text') and text.get_text()):
+            for text_type, text in [
+                ("xlabel", ax.xaxis.label),
+                ("ylabel", ax.yaxis.label),
+                ("title", ax.title),
+                ("left_title", getattr(ax, "_left_title", None)),
+                ("right_title", getattr(ax, "_right_title", None)),
+            ]:
+                if hasattr(text, 'get_text') and text.get_text():
                     self.draw_text(ax, text, force_trans=ax.transAxes,
-                                   text_type=ttp)
+                                   text_type=text_type)
             for artist in ax.artists:
                 # TODO: process other artists
                 if isinstance(artist, matplotlib.text.Text):


### PR DESCRIPTION
In matplotlib, an axis has three titles: default one, but also left and right ones (that's what `loc=` does). Export all three, if present.

One design question here was whether to export left/right titles as "title" too for text_type, or as separate types.

I checked, all existing exporters simply ignore the text_type argument, so there are no compatibility considerations. Then, I think more info is strictly better, and if one were ever to care about titles in general, one could still do `if "title" in text_type`.

(Again, this is export only and should be an easy merge; ~I'll send mpld3 rendering PR for this feature separately tomorrow~ Here it is: https://github.com/mpld3/mpld3/pull/548. I've had gpt-codex-5.2 help me figure it out, but I wrote the code in the end.)